### PR TITLE
Include submodules in `git clone` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The easiest way to get started is to clone
 `plugins` directory so you start with a clean slate.
 
 ```bash
-git clone https://github.com/sds/.files ~/.files
+git clone --recurse-submodules https://github.com/sds/.files ~/.files
 cd ~/.files
 rm -rf plugins/*
 bin/install


### PR DESCRIPTION
👋

I'm setting up a new system and wanted to get started with a solid sds foundation. After copy-pasting the get-started commands I got this error when I tried to run `bin/install`: 

```sh
bin/install: No such file or directory
```

The install script references a file in `../frameworks` which is a git submodule. We need the submodule to be checked out as well when we clone.