### PR TITLE
Update `diff` command for env change checking

### DIFF
--- a/libexec/dot::eval_env_file
+++ b/libexec/dot::eval_env_file
@@ -14,4 +14,4 @@ env | sort > "$prev_env_file"
 . "$1" >&2 # Source the file to load defined environment variables
 env | sort > "$new_env_file"
 
-diff --old-line-format "" --unchanged-line-format "" --new-line-format %L "$prev_env_file" "$new_env_file"
+diff --normal "$prev_env_file" "$new_env_file" | grep '^>' | cut -d">" -f2


### PR DESCRIPTION
This broke in macOS Ventura since they changed the `diff` tool, removing some flags we relied on.
